### PR TITLE
Change NEW_RELIC_NO_CONFIG to NEW_RELIC_NO_CONFIG_FILE

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1128,7 +1128,7 @@ function _noConfigFile() {
     "Unable to find New Relic module configuration. A default\n" +
     "configuration file can be copied from " + DEFAULT_CONFIG_PATH + "\n" +
     "and put at " + locations + ". If you are not using file based config\n" +
-    "please set the environment variable NEW_RELIC_NO_CONFIG=true"
+    "please set the environment variable NEW_RELIC_NO_CONFIG_FILE=true"
   )
 }
 


### PR DESCRIPTION
If configuration file can not be found, the message shown point to use wrong NEW_RELIC_NO_CONFIG instead NEW_RELIC_NO_CONFIG_FILE environment variable